### PR TITLE
Revert to No Extension Layout

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use hash_db::Hasher;
 use keccak_hasher::KeccakHasher;
 use pchain_types::cryptography::{PublicAddress, Sha256Hash};
@@ -8,7 +8,6 @@ use rocksdb::{DBWithThreadMode, MultiThreaded};
 use statrs::statistics::Statistics;
 use std::{
     collections::{HashMap, HashSet},
-    env::temp_dir,
     path::PathBuf,
     sync::{Arc, RwLock},
 };

--- a/src/storage_trie.rs
+++ b/src/storage_trie.rs
@@ -179,14 +179,7 @@ pub(crate) fn storage_key<V: VersionProvider>(key: &Vec<u8>) -> Vec<u8> {
         }
         Version::V2 => {
             let mut storage_key: Vec<u8> = Vec::new();
-            // Here `RefHasher` must be using the Keccak256 hash function.
-            if key.len() < RefHasher::LENGTH {
-                // 32 bytes
-                storage_key.extend_from_slice(key);
-            } else {
-                let hashed_key = RefHasher::hash(key);
-                storage_key.extend_from_slice(&hashed_key);
-            }
+            storage_key.extend_from_slice(key);
             storage_key
         }
     }


### PR DESCRIPTION
This branch reverts MPT V2 to continue using `NoExtensionLayout`. This include removing the hashing of storage keys longer than or equal to 32 bytes before inserting them into the backing MPT V2 of the storage trie.